### PR TITLE
Added optinal query to filter items by title when retrieving items

### DIFF
--- a/backend/app/api/dependencies/items.py
+++ b/backend/app/api/dependencies/items.py
@@ -22,6 +22,7 @@ def get_items_filters(
     tag: Optional[str] = None,
     seller: Optional[str] = None,
     favorited: Optional[str] = None,
+    title: Optional[str] = None,
     limit: int = Query(DEFAULT_ITEMS_LIMIT, ge=1),
     offset: int = Query(DEFAULT_ITEMS_OFFSET, ge=0),
 ) -> ItemsFilters:
@@ -29,6 +30,7 @@ def get_items_filters(
         tag=tag,
         seller=seller,
         favorited=favorited,
+        title=title,
         limit=limit,
         offset=offset,
     )

--- a/backend/app/api/routes/items/items_resource.py
+++ b/backend/app/api/routes/items/items_resource.py
@@ -39,6 +39,7 @@ async def list_items(
         seller=items_filters.seller,
         favorited=items_filters.favorited,
         limit=items_filters.limit,
+        title=items_filters.title,
         offset=items_filters.offset,
         requested_user=user,
     )

--- a/backend/app/db/repositories/items.py
+++ b/backend/app/db/repositories/items.py
@@ -106,6 +106,7 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
         tag: Optional[str] = None,
         seller: Optional[str] = None,
         favorited: Optional[str] = None,
+        title: Optional[str] = None,
         limit: int = 20,
         offset: int = 0,
         requested_user: Optional[User] = None,
@@ -194,6 +195,17 @@ class ItemsRepository(BaseRepository):  # noqa: WPS214
                         users.id,
                     )
                 ),
+            )
+            # fmt: on
+
+        if title:
+            like_title = "%{0}%".format(title)
+            query_params.append(like_title)
+            query_params_count += 1
+
+            # fmt: off
+            query = query.where(
+                items.title.ilike(Parameter(query_params_count)),
             )
             # fmt: on
 

--- a/backend/app/models/schemas/items.py
+++ b/backend/app/models/schemas/items.py
@@ -40,5 +40,6 @@ class ItemsFilters(BaseModel):
     tag: Optional[str] = None
     seller: Optional[str] = None
     favorited: Optional[str] = None
+    title: Optional[str] = None
     limit: int = Field(DEFAULT_ITEMS_LIMIT, ge=1)
     offset: int = Field(DEFAULT_ITEMS_OFFSET, ge=0)


### PR DESCRIPTION
Added an optional query 'title' to the '/api/items' endpoint to be able to filter items by their titles.
This change will allow the user to search for more specific items.